### PR TITLE
Updates for supported Swift versions.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,12 +26,18 @@ jobs:
       run: swift test -c debug
 
   macos:
+    strategy:
+      matrix:
+        swift-version:
+          - "4"
+          - "4.2"
+          - "5"
     name: macOS
     runs-on: macos-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Debug Build
-      run: swift build -c debug
+      run: swift build -c debug -Xswiftc -swift-version -Xswiftc ${{ matrix.swift-version }}
     - name: Debug Test
-      run: swift test -c debug
+      run: swift test -c debug -Xswiftc -swift-version -Xswiftc ${{ matrix.swift-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
           - "4"
           - "4.2"
           - "5"
-    name: macOS
+    name: macOS (Swift ${{ matrix.swift-version }})
     runs-on: macos-latest
     steps:
     - name: Checkout

--- a/ErrorAssertionExpectations.podspec
+++ b/ErrorAssertionExpectations.podspec
@@ -17,7 +17,7 @@ accurately test our error states.
   spec.ios.deployment_target = "8.0"
   spec.macos.deployment_target = "10.10"
   spec.tvos.deployment_target = "9.0"
-  spec.swift_versions = ['5.0', '5.1']
+  spec.swift_versions = ['4', '4.2', '5']
 
   spec.source       = { :git => "https://github.com/SlaunchaMan/ErrorAssertions.git",
                         :tag => "#{spec.version}" }

--- a/ErrorAssertions.podspec
+++ b/ErrorAssertions.podspec
@@ -17,7 +17,7 @@ Swift’s Error type instead of a simple String.
   spec.macos.deployment_target = "10.10"
   spec.watchos.deployment_target = "2.0"
   spec.tvos.deployment_target = "9.0"
-  spec.swift_versions = ['5.0', '5.1']
+  spec.swift_versions = ['4', '4.2', '5']
 
   spec.source       = { :git => "https://github.com/SlaunchaMan/ErrorAssertions.git",
                         :tag => "#{spec.version}" }

--- a/Package.swift
+++ b/Package.swift
@@ -17,5 +17,10 @@ let package = Package(
                         "ErrorAssertions",
                         "ErrorAssertionExpectations",
             ]),
+    ],
+    swiftLanguageVersions: [
+        .version("4"),
+        .version("4.2"),
+        .version("5")
     ]
 )


### PR DESCRIPTION
Supporting `4`, `4.2`, and `5`.